### PR TITLE
Add portability to bashLister.sh script

### DIFF
--- a/bashLister.sh
+++ b/bashLister.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Wordlist generator
 


### PR DESCRIPTION
Modify portability of the script by modifying the Shebang value to a portable shell.

using `#!/usr/bin/env bash` will allow script to run with any bash without depending on it being in the same location as the script one